### PR TITLE
Move plugin to new Github organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sonarscanner-buildkite-plugin
 =============================
 
-[![Actions Status](https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin/workflows/Lint/badge.svg?branch=master)](https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin/actions) [![Actions Status](https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin/actions) ![Version](https://img.shields.io/static/v1.svg?label=Version&message=0.1.1&color=lightgrey&?link=http://left&link=https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin/tree/v0.1.1) ![Plugin Status](https://img.shields.io/static/v1.svg?label=&message=Buildkite%20Plugin&color=blue&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAMAAADVRocKAAAAk1BMVEX///+DrRik1Cb+/vyErhin1yeAqhfJ5n+dzCO50X2VwiC2zna020vg8LSo1i+q1zTN3qL7/fav2UDT4q33++yXuj3z+eLO6IqMuByJsSPM54XX5bWcvUbH5Xrg6sWiwVHB1ovk7cymxFnq8deOtC2xzG7c6L6/1YfU7JbI2pj2+e+jzzPd763K3J3j8ryRtDbY7aOqCe3pAAACTElEQVRoge3Z11KDQBSAYUpItSRqVGwxEVOwxPd/OndhCbA5BTaLM87sueb83+yMStHz3Lhx48bN/5iw+2VjImy0fDvzQiNCLKVrdjn0nq++QwNCLMy+9uOzc2Y59AZBwF4F55NefxxxyxK4aEvI/C7x/QxglrMTBNxVej6V+QNALh+AhkRY5isAsVwBxFWfM/rnLsu/qnwNQIkawBBy/abMawBCaEAQXGFElt/Evo8CIHEEIESWH9XyAAAQACCIH40A8yBwRICARiB5BNAIBKgQ8tLbCZBHgRqBAgWB5wmgQhCAIt7ekTwJ5AQHSGKC1TkgiM7WIs8A0bBvCETR8H7CA4EhIPP9fgPA7AR53u91BBR53+8EKPPdACLvq3wXQC1vH9DytoGjvF0gGo71vE0gCoC8PQDJ2wJEvgfmbQFo3g5A5HNA3K+eL0yBePdO5AtAEAOUoIB4c+ONiHwBZHddjMCB5DUV6yOqfzgBQWCAzMu9ZoAiHgACBpJdmj3SNAdQAgKSXfFQ1gZQz28PlxxQ5tsCIKED+6/qU2tbQBF3lxgwn9YfitsDR0QVmE9D7bHeBNCIEphf63lToEYUAJQ3BxSxlUQGPD3Cr5DmwIGQJ8DypwHqlXX7gec5oMcAXv5OT31OYU6weuM/9tDv/iSwWnJxfghA5s0+QzUCFi828iiwWNvJI4C9PAg8WcwDAPVLYwGwndeAufV8DZB/bm3nK0A3+RyI81tdF3l1gn1neQlM4qnpp+9ms0xP/P8AP/8778aNGzdu/mh+AQp1NCB/JInXAAAAAElFTkSuQmCC)
+[![Actions Status](https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin/workflows/Lint/badge.svg?branch=master)](https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin/actions) [![Actions Status](https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin/actions) ![Version](https://img.shields.io/static/v1.svg?label=Version&message=0.1.1&color=lightgrey&?link=http://left&link=https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin/tree/v0.1.1) ![Plugin Status](https://img.shields.io/static/v1.svg?label=&message=Buildkite%20Plugin&color=blue&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAMAAADVRocKAAAAk1BMVEX///+DrRik1Cb+/vyErhin1yeAqhfJ5n+dzCO50X2VwiC2zna020vg8LSo1i+q1zTN3qL7/fav2UDT4q33++yXuj3z+eLO6IqMuByJsSPM54XX5bWcvUbH5Xrg6sWiwVHB1ovk7cymxFnq8deOtC2xzG7c6L6/1YfU7JbI2pj2+e+jzzPd763K3J3j8ryRtDbY7aOqCe3pAAACTElEQVRoge3Z11KDQBSAYUpItSRqVGwxEVOwxPd/OndhCbA5BTaLM87sueb83+yMStHz3Lhx48bN/5iw+2VjImy0fDvzQiNCLKVrdjn0nq++QwNCLMy+9uOzc2Y59AZBwF4F55NefxxxyxK4aEvI/C7x/QxglrMTBNxVej6V+QNALh+AhkRY5isAsVwBxFWfM/rnLsu/qnwNQIkawBBy/abMawBCaEAQXGFElt/Evo8CIHEEIESWH9XyAAAQACCIH40A8yBwRICARiB5BNAIBKgQ8tLbCZBHgRqBAgWB5wmgQhCAIt7ekTwJ5AQHSGKC1TkgiM7WIs8A0bBvCETR8H7CA4EhIPP9fgPA7AR53u91BBR53+8EKPPdACLvq3wXQC1vH9DytoGjvF0gGo71vE0gCoC8PQDJ2wJEvgfmbQFo3g5A5HNA3K+eL0yBePdO5AtAEAOUoIB4c+ONiHwBZHddjMCB5DUV6yOqfzgBQWCAzMu9ZoAiHgACBpJdmj3SNAdQAgKSXfFQ1gZQz28PlxxQ5tsCIKED+6/qU2tbQBF3lxgwn9YfitsDR0QVmE9D7bHeBNCIEphf63lToEYUAJQ3BxSxlUQGPD3Cr5DmwIGQJ8DypwHqlXX7gec5oMcAXv5OT31OYU6weuM/9tDv/iSwWnJxfghA5s0+QzUCFi828iiwWNvJI4C9PAg8WcwDAPVLYwGwndeAufV8DZB/bm3nK0A3+RyI81tdF3l1gn1neQlM4qnpp+9ms0xP/P8AP/8778aNGzdu/mh+AQp1NCB/JInXAAAAAElFTkSuQmCC)
 
 This plugin performs static code analysis as part of a Buildkite pipeline and reports back to Sonarqube.
 
@@ -25,7 +25,7 @@ steps:
   - label: ":sonarqube: Sonarqube"
     branches: "master" # only report on the master branch
     plugins:
-      - ssh://git@github.com/wayfair-contribs/sonarscanner-buildkite-plugin.git#v0.1.1:
+      - wayfair-incubator/sonarscanner#v0.1.1:
           sonarqube_host: https://sonarqube.example.com
           project_key: sonarqube_project_key
     soft_fail: # Ensures a Sonarqube error does not fail the pipeline
@@ -43,7 +43,7 @@ The plugin supports paid Sonarqube features, such as enabling scans for a `branc
 steps:
   - label: ":sonarqube: Sonarqube"
     plugins:
-      - ssh://git@github.com/wayfair-contribs/sonarscanner-buildkite-plugin.git#v0.1.1:
+      - wayfair-incubator/sonarscanner#v0.1.1:
           sonarqube_host: https://sonarqube_enterprise.example.com
           project_key: sonarqube_project_key
           uses_community_edition: false
@@ -71,7 +71,7 @@ steps:
 
   - label: ":sonarqube: Sonarqube"
     plugins:
-      - ssh://git@github.com/wayfair-contribs/sonarscanner-buildkite-plugin.git#v0.1.1:
+      - wayfair-incubator/sonarscanner#v0.1.1:
           sonarqube_host: https://sonarqube.example.com
           project_key: sonarqube_project_key
           artifacts: tmp/*coverage-*.xml
@@ -106,7 +106,7 @@ steps:
 
   - label: ":sonarqube: Sonarqube"
     plugins:
-      - ssh://git@github.com/wayfair-contribs/sonarscanner-buildkite-plugin.git#v0.1.1:
+      - wayfair-incubator/sonarscanner#v0.1.1:
           sonarqube_host: https://sonarqube.example.com
           project_key: sonarqube_project_key
           is_dotnet: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,6 @@ services:
 
   plugin-lint:
     image: buildkite/plugin-linter
-    command:
-      [
-        "--id=ssh://git@github.com/wayfair-contribs/sonarscanner-buildkite-plugin.git",
-      ]
+    command: ["--id", "wayfair-incubator/sonarscanner"]
     volumes:
       - ".:/plugin:ro"

--- a/docker/sonarscanner-dotnet.dockerfile
+++ b/docker/sonarscanner-dotnet.dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0
 
 ARG VERSION=${PLUGIN_VERSION}
 ARG DESCRIPTION="Run sonar-scanner in a .NET Docker container"
-ARG VCS_URL="https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin"
+ARG VCS_URL="https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin"
 
 USER root
 

--- a/docker/sonarscanner.dockerfile
+++ b/docker/sonarscanner.dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 ARG SONAR_SCANNER_VERSION=${SONAR_SCANNER_VERSION:-4.2.0.1873}
 ARG VERSION=${PLUGIN_VERSION}
 ARG DESCRIPTION="Run sonar-scanner in Docker"
-ARG VCS_URL="https://github.com/wayfair-contribs/sonarscanner-buildkite-plugin"
+ARG VCS_URL="https://github.com/wayfair-incubator/sonarscanner-buildkite-plugin"
 
 USER root
 


### PR DESCRIPTION
## Summary

The plugin has been moved from the `wayfair-contribs` to the `wayfair-incubator` Github organization, so all occurrences of the text in the plugin have been updated accordingly.

## PR Checklist

Please run through before submitting for final review:

- [x] The PR title is descriptive of what changed.
- [x] The description sections above are filled out.
- [x] The CI pipeline is passing
- [x] Added the `ready-for-review` label to the PR.
